### PR TITLE
update Math.sol path

### DIFF
--- a/contracts/mocks/MathMock.sol
+++ b/contracts/mocks/MathMock.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.4.21;
 
 
-import "../../contracts/math/Math.sol";
+import "../math/Math.sol";
 
 
 contract MathMock {


### PR DESCRIPTION
To use openzeppelin-zos Math.sol

<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. **Does this close any open issues?** If so, list them here. If not, remove the `Fixes #` line. -->

<!-- Fixes # -->

# 🚀 Description

<!-- 2. Describe the changes introduced in this pull request -->
<!--    Include any context necessary for understanding the PR's purpose. -->
MathMock contract imports a file that exists only if the "contracts" folder is named contracts.
This PR fixes it so it uses a relative path.

ISSUE
- If file is in: repo/contracts/openzeppelin/mocks/MathMock.sol
- It imports (fails) repo/contracts/contracts/math/Math.sol

FIX
- If file is in: repo/contracts/openzeppelin/mocks/MathMock.sol
- It imports (success) repo/contracts/openzeppelin/math/Math.sol

<!-- 3. Before submitting, please review the following checklist: -->

- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](../blob/master/CONTRIBUTING.md)
- [N/A?] ✅ I've added tests where applicable to test my new functionality.
- [N/A?] 📖 I've made sure that my contracts are well-documented.
- [N/A?] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).
