### PR TITLE
Initialization improvements

### DIFF
--- a/contracts/mocks/AllowanceCrowdsaleImpl.sol
+++ b/contracts/mocks/AllowanceCrowdsaleImpl.sol
@@ -1,11 +1,10 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/emission/AllowanceCrowdsale.sol";
 
 
-contract AllowanceCrowdsaleImpl is Initializable, Crowdsale, AllowanceCrowdsale {
+contract AllowanceCrowdsaleImpl is AllowanceCrowdsale {
 
   constructor (
     uint256 rate,

--- a/contracts/mocks/BreakInvariantBountyMock.sol
+++ b/contracts/mocks/BreakInvariantBountyMock.sol
@@ -4,10 +4,9 @@ pragma solidity ^0.4.24;
 // See: https://github.com/ethereum/solidity/issues/4871
 // solium-disable-next-line max-len
 import {BreakInvariantBounty, Target} from "../drafts/BreakInvariantBounty.sol";
-import "../Initializable.sol";
 
 
-contract TargetMock is Initializable, Target {
+contract TargetMock is Target {
   bool private exploited;
 
   function exploitVulnerability() public {
@@ -23,7 +22,7 @@ contract TargetMock is Initializable, Target {
   }
 }
 
-contract BreakInvariantBountyMock is Initializable, BreakInvariantBounty {
+contract BreakInvariantBountyMock is BreakInvariantBounty {
   constructor() public {
     BreakInvariantBounty.initialize();
   }

--- a/contracts/mocks/CappedCrowdsaleImpl.sol
+++ b/contracts/mocks/CappedCrowdsaleImpl.sol
@@ -1,11 +1,10 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/validation/CappedCrowdsale.sol";
 
 
-contract CappedCrowdsaleImpl is Initializable, Crowdsale, CappedCrowdsale {
+contract CappedCrowdsaleImpl is CappedCrowdsale {
 
   constructor (
     uint256 rate,

--- a/contracts/mocks/CapperRoleMock.sol
+++ b/contracts/mocks/CapperRoleMock.sol
@@ -1,10 +1,9 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../access/roles/CapperRole.sol";
 
 
-contract CapperRoleMock is Initializable, CapperRole {
+contract CapperRoleMock is CapperRole {
   constructor() public {
     CapperRole.initialize();
   }

--- a/contracts/mocks/ConditionalEscrowMock.sol
+++ b/contracts/mocks/ConditionalEscrowMock.sol
@@ -1,12 +1,10 @@
 pragma solidity ^0.4.24;
 
-
-import "../Initializable.sol";
 import "../payment/ConditionalEscrow.sol";
 
 
 // mock class using ConditionalEscrow
-contract ConditionalEscrowMock is Initializable, ConditionalEscrow {
+contract ConditionalEscrowMock is ConditionalEscrow {
   mapping(address => bool) private _allowed;
 
   constructor() public {

--- a/contracts/mocks/CrowdsaleMock.sol
+++ b/contracts/mocks/CrowdsaleMock.sol
@@ -1,10 +1,9 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../crowdsale/Crowdsale.sol";
 
 
-contract CrowdsaleMock is Initializable, Crowdsale {
+contract CrowdsaleMock is Crowdsale {
   constructor(uint256 rate, address wallet, IERC20 token) public {
     Crowdsale.initialize(rate, wallet, token);
   }

--- a/contracts/mocks/DetailedERC20Mock.sol
+++ b/contracts/mocks/DetailedERC20Mock.sol
@@ -1,11 +1,10 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../token/ERC20/ERC20.sol";
 import "../token/ERC20/ERC20Detailed.sol";
 
 
-contract ERC20DetailedMock is Initializable, ERC20, ERC20Detailed {
+contract ERC20DetailedMock is ERC20, ERC20Detailed {
   constructor(
     string name,
     string symbol,

--- a/contracts/mocks/ECDSAMock.sol
+++ b/contracts/mocks/ECDSAMock.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.4.24;
 
-
 import "../cryptography/ECDSA.sol";
 
 

--- a/contracts/mocks/ERC20BurnableMock.sol
+++ b/contracts/mocks/ERC20BurnableMock.sol
@@ -1,10 +1,9 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../token/ERC20/ERC20Burnable.sol";
 
 
-contract ERC20BurnableMock is Initializable, ERC20Burnable {
+contract ERC20BurnableMock is ERC20Burnable {
 
   constructor(address initialAccount, uint256 initialBalance) public {
     _mint(initialAccount, initialBalance);

--- a/contracts/mocks/ERC20CappedMock.sol
+++ b/contracts/mocks/ERC20CappedMock.sol
@@ -1,11 +1,10 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../token/ERC20/ERC20Capped.sol";
 import "./MinterRoleMock.sol";
 
 
-contract ERC20CappedMock is Initializable, ERC20Capped, MinterRoleMock {
+contract ERC20CappedMock is ERC20Capped, MinterRoleMock {
 
   constructor(uint256 cap) public {
     ERC20Capped.initialize(cap);

--- a/contracts/mocks/ERC20MigratorMock.sol
+++ b/contracts/mocks/ERC20MigratorMock.sol
@@ -1,10 +1,9 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../drafts/ERC20Migrator.sol";
 
 
-contract ERC20MigratorMock is Initializable, ERC20Migrator {
+contract ERC20MigratorMock is ERC20Migrator {
 
   constructor(IERC20 legacyToken) public {
     ERC20Migrator.initialize(legacyToken);

--- a/contracts/mocks/ERC20MintableMock.sol
+++ b/contracts/mocks/ERC20MintableMock.sol
@@ -1,11 +1,10 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../token/ERC20/ERC20Mintable.sol";
 import "./MinterRoleMock.sol";
 
 
-contract ERC20MintableMock is Initializable, ERC20Mintable, MinterRoleMock {
+contract ERC20MintableMock is ERC20Mintable, MinterRoleMock {
 
   constructor() public {
     ERC20Mintable.initialize();

--- a/contracts/mocks/ERC20Mock.sol
+++ b/contracts/mocks/ERC20Mock.sol
@@ -1,11 +1,10 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../token/ERC20/ERC20.sol";
 
 
 // mock class using ERC20
-contract ERC20Mock is Initializable, ERC20 {
+contract ERC20Mock is ERC20 {
 
   constructor(address initialAccount, uint256 initialBalance) public {
     _mint(initialAccount, initialBalance);

--- a/contracts/mocks/ERC20PausableMock.sol
+++ b/contracts/mocks/ERC20PausableMock.sol
@@ -1,12 +1,11 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../token/ERC20/ERC20Pausable.sol";
 import "./PauserRoleMock.sol";
 
 
 // mock class using ERC20Pausable
-contract ERC20PausableMock is Initializable, ERC20Pausable, PauserRoleMock {
+contract ERC20PausableMock is ERC20Pausable, PauserRoleMock {
 
   constructor(address initialAccount, uint initialBalance) public {
     ERC20Pausable.initialize();

--- a/contracts/mocks/ERC20WithMetadataMock.sol
+++ b/contracts/mocks/ERC20WithMetadataMock.sol
@@ -1,11 +1,10 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../token/ERC20/ERC20.sol";
 import "../drafts/ERC1046/TokenMetadata.sol";
 
 
-contract ERC20WithMetadataMock is Initializable, ERC20, ERC20WithMetadata {
+contract ERC20WithMetadataMock is ERC20, ERC20WithMetadata {
   constructor(string tokenURI) public {
     ERC20WithMetadata.initialize(tokenURI);
   }

--- a/contracts/mocks/ERC721FullMock.sol
+++ b/contracts/mocks/ERC721FullMock.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../token/ERC721/ERC721Full.sol";
 import "../token/ERC721/ERC721Mintable.sol";
 import "../token/ERC721/ERC721MetadataMintable.sol";
@@ -12,11 +11,12 @@ import "../token/ERC721/ERC721Burnable.sol";
  * This mock just provides a public mint and burn functions for testing purposes,
  * and a public setter for metadata URI
  */
-contract ERC721FullMock is Initializable, ERC721Full, ERC721Mintable, ERC721MetadataMintable, ERC721Burnable {
+contract ERC721FullMock is ERC721Full, ERC721Mintable, ERC721MetadataMintable, ERC721Burnable {
   constructor(string name, string symbol) public
   {
     ERC721Full.initialize(name, symbol);
     ERC721Mintable.initialize();
+    ERC721Burnable.initialize();
   }
 
   function exists(uint256 tokenId) public view returns (bool) {

--- a/contracts/mocks/ERC721MintableBurnableImpl.sol
+++ b/contracts/mocks/ERC721MintableBurnableImpl.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../token/ERC721/ERC721Full.sol";
 import "../token/ERC721/ERC721Mintable.sol";
 import "../token/ERC721/ERC721MetadataMintable.sol";
@@ -11,13 +10,14 @@ import "../token/ERC721/ERC721Burnable.sol";
  * @title ERC721MintableBurnableImpl
  */
 contract ERC721MintableBurnableImpl
-  is Initializable, ERC721Full, ERC721Mintable, ERC721MetadataMintable, ERC721Burnable {
+  is ERC721Full, ERC721Mintable, ERC721MetadataMintable, ERC721Burnable {
 
   constructor()
     public
   {
     ERC721Full.initialize("Test", "TEST");
     ERC721Mintable.initialize();
+    ERC721MetadataMintable.initialize();
     ERC721Burnable.initialize();
   }
 }

--- a/contracts/mocks/ERC721Mock.sol
+++ b/contracts/mocks/ERC721Mock.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../token/ERC721/ERC721.sol";
 
 
@@ -8,7 +7,7 @@ import "../token/ERC721/ERC721.sol";
  * @title ERC721Mock
  * This mock just provides a public mint and burn functions for testing purposes
  */
-contract ERC721Mock is Initializable, ERC721 {
+contract ERC721Mock is ERC721 {
   constructor() public {
     ERC721.initialize();
   }

--- a/contracts/mocks/ERC721PausableMock.sol
+++ b/contracts/mocks/ERC721PausableMock.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../token/ERC721/ERC721Pausable.sol";
 import "./PauserRoleMock.sol";
 
@@ -9,7 +8,7 @@ import "./PauserRoleMock.sol";
  * @title ERC721PausableMock
  * This mock just provides a public mint, burn and exists functions for testing purposes
  */
-contract ERC721PausableMock is Initializable, ERC721Pausable, PauserRoleMock {
+contract ERC721PausableMock is ERC721Pausable, PauserRoleMock {
   constructor() {
     ERC721Pausable.initialize();
   }

--- a/contracts/mocks/EscrowMock.sol
+++ b/contracts/mocks/EscrowMock.sol
@@ -1,9 +1,8 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../payment/Escrow.sol";
 
-contract EscrowMock is Initializable, Escrow {
+contract EscrowMock is Escrow {
   constructor() public {
     Escrow.initialize();
   }

--- a/contracts/mocks/FinalizableCrowdsaleImpl.sol
+++ b/contracts/mocks/FinalizableCrowdsaleImpl.sol
@@ -1,11 +1,10 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/distribution/FinalizableCrowdsale.sol";
 
 
-contract FinalizableCrowdsaleImpl is Initializable, Crowdsale, TimedCrowdsale, FinalizableCrowdsale {
+contract FinalizableCrowdsaleImpl is FinalizableCrowdsale {
 
   constructor (
     uint256 openingTime,

--- a/contracts/mocks/IncreasingPriceCrowdsaleImpl.sol
+++ b/contracts/mocks/IncreasingPriceCrowdsaleImpl.sol
@@ -1,11 +1,10 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../crowdsale/price/IncreasingPriceCrowdsale.sol";
 import "../math/SafeMath.sol";
 
 
-contract IncreasingPriceCrowdsaleImpl is Initializable, IncreasingPriceCrowdsale {
+contract IncreasingPriceCrowdsaleImpl is IncreasingPriceCrowdsale {
 
   constructor (
     uint256 openingTime,

--- a/contracts/mocks/IndividuallyCappedCrowdsaleImpl.sol
+++ b/contracts/mocks/IndividuallyCappedCrowdsaleImpl.sol
@@ -1,13 +1,12 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/validation/IndividuallyCappedCrowdsale.sol";
 import "./CapperRoleMock.sol";
 
 
 contract IndividuallyCappedCrowdsaleImpl
-  is Initializable, Crowdsale, IndividuallyCappedCrowdsale, CapperRoleMock {
+  is Crowdsale, IndividuallyCappedCrowdsale, CapperRoleMock {
 
   constructor(
     uint256 rate,

--- a/contracts/mocks/MintedCrowdsaleImpl.sol
+++ b/contracts/mocks/MintedCrowdsaleImpl.sol
@@ -1,11 +1,10 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../token/ERC20/ERC20Mintable.sol";
 import "../crowdsale/emission/MintedCrowdsale.sol";
 
 
-contract MintedCrowdsaleImpl is Initializable, MintedCrowdsale {
+contract MintedCrowdsaleImpl is MintedCrowdsale {
 
   constructor (
     uint256 rate,

--- a/contracts/mocks/MinterRoleMock.sol
+++ b/contracts/mocks/MinterRoleMock.sol
@@ -1,10 +1,9 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../access/roles/MinterRole.sol";
 
 
-contract MinterRoleMock is Initializable, MinterRole {
+contract MinterRoleMock is MinterRole {
   constructor() public {
     MinterRole.initialize();
   }

--- a/contracts/mocks/OwnableMock.sol
+++ b/contracts/mocks/OwnableMock.sol
@@ -5,7 +5,6 @@ import { Ownable } from "../ownership/Ownable.sol";
 contract OwnableMock is Ownable {
 
   constructor() {
-    initialize();
+    Ownable.initialize();
   }
-
 }

--- a/contracts/mocks/PausableMock.sol
+++ b/contracts/mocks/PausableMock.sol
@@ -1,13 +1,11 @@
 pragma solidity ^0.4.24;
 
-
-import "../Initializable.sol";
 import "../lifecycle/Pausable.sol";
 import "./PauserRoleMock.sol";
 
 
 // mock class using Pausable
-contract PausableMock is Initializable, Pausable, PauserRoleMock {
+contract PausableMock is Pausable, PauserRoleMock {
   bool public drasticMeasureTaken;
   uint256 public count;
 

--- a/contracts/mocks/PauserRoleMock.sol
+++ b/contracts/mocks/PauserRoleMock.sol
@@ -1,10 +1,9 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../access/roles/PauserRole.sol";
 
 
-contract PauserRoleMock is Initializable, PauserRole {
+contract PauserRoleMock is PauserRole {
   constructor() public {
     PauserRole.initialize();
   }

--- a/contracts/mocks/PostDeliveryCrowdsaleImpl.sol
+++ b/contracts/mocks/PostDeliveryCrowdsaleImpl.sol
@@ -1,11 +1,10 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/distribution/PostDeliveryCrowdsale.sol";
 
 
-contract PostDeliveryCrowdsaleImpl is Initializable, Crowdsale, TimedCrowdsale, PostDeliveryCrowdsale {
+contract PostDeliveryCrowdsaleImpl is PostDeliveryCrowdsale {
 
   constructor (
     uint256 openingTime,

--- a/contracts/mocks/PullPaymentMock.sol
+++ b/contracts/mocks/PullPaymentMock.sol
@@ -1,12 +1,11 @@
 pragma solidity ^0.4.24;
 
 
-import "../Initializable.sol";
 import "../payment/PullPayment.sol";
 
 
 // mock class using PullPayment
-contract PullPaymentMock is Initializable, PullPayment {
+contract PullPaymentMock is PullPayment {
 
   constructor() public payable {
     PullPayment.initialize();

--- a/contracts/mocks/ReentrancyMock.sol
+++ b/contracts/mocks/ReentrancyMock.sol
@@ -1,11 +1,10 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../utils/ReentrancyGuard.sol";
 import "./ReentrancyAttack.sol";
 
 
-contract ReentrancyMock is Initializable, ReentrancyGuard {
+contract ReentrancyMock is ReentrancyGuard {
 
   uint256 public counter;
 

--- a/contracts/mocks/RefundEscrowMock.sol
+++ b/contracts/mocks/RefundEscrowMock.sol
@@ -1,9 +1,8 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../payment/RefundEscrow.sol";
 
-contract RefundEscrowMock is Initializable, RefundEscrow {
+contract RefundEscrowMock is RefundEscrow {
   constructor(address beneficiary) public {
     RefundEscrow.initialize(beneficiary);
   }

--- a/contracts/mocks/RefundableCrowdsaleImpl.sol
+++ b/contracts/mocks/RefundableCrowdsaleImpl.sol
@@ -1,11 +1,10 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../token/ERC20/ERC20Mintable.sol";
 import "../crowdsale/distribution/RefundableCrowdsale.sol";
 
 
-contract RefundableCrowdsaleImpl is Initializable, Crowdsale, TimedCrowdsale, RefundableCrowdsale {
+contract RefundableCrowdsaleImpl is Crowdsale, TimedCrowdsale, RefundableCrowdsale {
 
   constructor (
     uint256 openingTime,

--- a/contracts/mocks/SampleCrowdsaleMock.sol
+++ b/contracts/mocks/SampleCrowdsaleMock.sol
@@ -1,16 +1,15 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../examples/SampleCrowdsale.sol";
 
 
-contract SampleCrowdsaleTokenMock is Initializable, SampleCrowdsaleToken {
+contract SampleCrowdsaleTokenMock is SampleCrowdsaleToken {
   constructor() public {
     SampleCrowdsaleToken.initialize();
   }
 }
 
-contract SampleCrowdsaleMock is Initializable,  SampleCrowdsale {
+contract SampleCrowdsaleMock is SampleCrowdsale {
   constructor(
     uint256 openingTime,
     uint256 closingTime,

--- a/contracts/mocks/SecondaryMock.sol
+++ b/contracts/mocks/SecondaryMock.sol
@@ -1,10 +1,9 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../ownership/Secondary.sol";
 
 
-contract SecondaryMock is Initializable, Secondary {
+contract SecondaryMock is Secondary {
   constructor() public {
     Secondary.initialize();
   }

--- a/contracts/mocks/SignatureBouncerMock.sol
+++ b/contracts/mocks/SignatureBouncerMock.sol
@@ -1,11 +1,10 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../drafts/SignatureBouncer.sol";
 import "./SignerRoleMock.sol";
 
 
-contract SignatureBouncerMock is Initializable, SignatureBouncer, SignerRoleMock {
+contract SignatureBouncerMock is SignatureBouncer, SignerRoleMock {
   constructor() public {
     SignatureBouncer.initialize();
   }

--- a/contracts/mocks/SignerRoleMock.sol
+++ b/contracts/mocks/SignerRoleMock.sol
@@ -1,10 +1,9 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../access/roles/SignerRole.sol";
 
 
-contract SignerRoleMock is Initializable, SignerRole {
+contract SignerRoleMock is SignerRole {
   constructor() public {
     SignerRole.initialize();
   }

--- a/contracts/mocks/SimpleTokenMock.sol
+++ b/contracts/mocks/SimpleTokenMock.sol
@@ -1,9 +1,8 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../examples/SimpleToken.sol";
 
-contract SimpleTokenMock is Initializable, SimpleToken {
+contract SimpleTokenMock is SimpleToken {
   constructor() public {
     SimpleToken.initialize();
   }

--- a/contracts/mocks/SplitPaymentMock.sol
+++ b/contracts/mocks/SplitPaymentMock.sol
@@ -1,9 +1,8 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../payment/SplitPayment.sol";
 
-contract SplitPaymentMock is Initializable, SplitPayment {
+contract SplitPaymentMock is SplitPayment {
   constructor(address[] payees, uint256[] shares) public {
     SplitPayment.initialize(payees, shares);
   }

--- a/contracts/mocks/TimedCrowdsaleImpl.sol
+++ b/contracts/mocks/TimedCrowdsaleImpl.sol
@@ -1,11 +1,10 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/validation/TimedCrowdsale.sol";
 
 
-contract TimedCrowdsaleImpl is Initializable, Crowdsale, TimedCrowdsale {
+contract TimedCrowdsaleImpl is TimedCrowdsale {
 
   constructor (
     uint256 openingTime,

--- a/contracts/mocks/TokenTimelockMock.sol
+++ b/contracts/mocks/TokenTimelockMock.sol
@@ -1,9 +1,8 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../token/ERC20/TokenTimelock.sol";
 
-contract TokenTimelockMock is Initializable, TokenTimelock {
+contract TokenTimelockMock is TokenTimelock {
   constructor(
     IERC20 token,
     address beneficiary,

--- a/contracts/mocks/TokenVestingMock.sol
+++ b/contracts/mocks/TokenVestingMock.sol
@@ -1,9 +1,8 @@
 pragma solidity ^0.4.24;
 
-import "../Initializable.sol";
 import "../drafts/TokenVesting.sol";
 
-contract TokenVestingMock is Initializable, TokenVesting {
+contract TokenVestingMock is TokenVesting {
   constructor(
     address beneficiary,
     uint256 start,

--- a/contracts/token/ERC721/ERC721MetadataMintable.sol
+++ b/contracts/token/ERC721/ERC721MetadataMintable.sol
@@ -11,6 +11,7 @@ import "../../access/roles/MinterRole.sol";
  */
 contract ERC721MetadataMintable is Initializable, ERC721, ERC721Metadata, MinterRole {
   function initialize() public initializer {
+    ERC721.initialize();
     MinterRole.initialize();
   }
 

--- a/contracts/token/ERC721/ERC721MetadataMintable.sol
+++ b/contracts/token/ERC721/ERC721MetadataMintable.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.4.24;
 
+import "../../Initializable.sol";
 import "./ERC721Metadata.sol";
 import "../../access/roles/MinterRole.sol";
 
@@ -8,7 +9,11 @@ import "../../access/roles/MinterRole.sol";
  * @title ERC721MetadataMintable
  * @dev ERC721 minting logic with metadata
  */
-contract ERC721MetadataMintable is ERC721, ERC721Metadata, MinterRole {
+contract ERC721MetadataMintable is Initializable, ERC721, ERC721Metadata, MinterRole {
+  function initialize() public initializer {
+    MinterRole.initialize();
+  }
+
   /**
    * @dev Function to mint tokens
    * @param to The address that will receive the minted tokens.

--- a/contracts/token/ERC721/ERC721Mintable.sol
+++ b/contracts/token/ERC721/ERC721Mintable.sol
@@ -11,6 +11,7 @@ import "../../access/roles/MinterRole.sol";
  */
 contract ERC721Mintable is Initializable, ERC721, MinterRole {
   function initialize() public initializer {
+    ERC721.initialize();
     MinterRole.initialize();
   }
 


### PR DESCRIPTION
This mainly removes `Initializable` from all mocks, but also adds a couple missing `initialize` calls

Builds on top of #23. See [here](https://github.com/nventuro/openzeppelin-zos/compare/oz-sol-rc3...nventuro:init-improvs) for a more accurate changeset until that is merged.