### PR TITLE
Added sender parameter to initializers using msg.sender.

### DIFF
--- a/contracts/access/roles/CapperRole.sol
+++ b/contracts/access/roles/CapperRole.sol
@@ -12,9 +12,9 @@ contract CapperRole is Initializable {
 
   Roles.Role private cappers;
 
-  function initialize() public initializer {
-    if (!isCapper(msg.sender)) {
-      _addCapper(msg.sender);
+  function initialize(address sender) public initializer {
+    if (!isCapper(sender)) {
+      _addCapper(sender);
     }
   }
 

--- a/contracts/access/roles/MinterRole.sol
+++ b/contracts/access/roles/MinterRole.sol
@@ -12,9 +12,9 @@ contract MinterRole is Initializable {
 
   Roles.Role private minters;
 
-  function initialize() public initializer {
-    if (!isMinter(msg.sender)) {
-      _addMinter(msg.sender);
+  function initialize(address sender) public initializer {
+    if (!isMinter(sender)) {
+      _addMinter(sender);
     }
   }
 

--- a/contracts/access/roles/PauserRole.sol
+++ b/contracts/access/roles/PauserRole.sol
@@ -12,9 +12,9 @@ contract PauserRole is Initializable {
 
   Roles.Role private pausers;
 
-  function initialize() public initializer {
-    if (!isPauser(msg.sender)) {
-      _addPauser(msg.sender);
+  function initialize(address sender) public initializer {
+    if (!isPauser(sender)) {
+      _addPauser(sender);
     }
   }
 

--- a/contracts/access/roles/SignerRole.sol
+++ b/contracts/access/roles/SignerRole.sol
@@ -12,9 +12,9 @@ contract SignerRole is Initializable {
 
   Roles.Role private signers;
 
-  function initialize() public initializer {
-    if (!isSigner(msg.sender)) {
-      _addSigner(msg.sender);
+  function initialize(address sender) public initializer {
+    if (!isSigner(sender)) {
+      _addSigner(sender);
     }
   }
 

--- a/contracts/crowdsale/distribution/RefundableCrowdsale.sol
+++ b/contracts/crowdsale/distribution/RefundableCrowdsale.sol
@@ -31,7 +31,7 @@ contract RefundableCrowdsale is Initializable, FinalizableCrowdsale {
     // conditional added to make initializer idempotent in case of diamond inheritance
     if (address(_escrow) == address(0)) {
       _escrow = new RefundEscrow();
-      _escrow.initialize(wallet());
+      _escrow.initialize(wallet(), address(this));
     }
 
     _goal = goal;

--- a/contracts/crowdsale/validation/IndividuallyCappedCrowdsale.sol
+++ b/contracts/crowdsale/validation/IndividuallyCappedCrowdsale.sol
@@ -16,8 +16,8 @@ contract IndividuallyCappedCrowdsale is Initializable, Crowdsale, CapperRole {
   mapping(address => uint256) private _contributions;
   mapping(address => uint256) private _caps;
 
-  function initialize() public initializer {
-    CapperRole.initialize();
+  function initialize(address sender) public initializer {
+    CapperRole.initialize(sender);
   }
 
   /**

--- a/contracts/drafts/BreakInvariantBounty.sol
+++ b/contracts/drafts/BreakInvariantBounty.sol
@@ -16,9 +16,9 @@ contract BreakInvariantBounty is Initializable, PullPayment, Ownable {
 
   event TargetCreated(address createdAddress);
 
-  function initialize() public initializer {
+  function initialize(address sender) public initializer {
     PullPayment.initialize();
-    Ownable.initialize();
+    Ownable.initialize(sender);
   }
 
   /**

--- a/contracts/drafts/SignatureBouncer.sol
+++ b/contracts/drafts/SignatureBouncer.sol
@@ -65,8 +65,8 @@ contract SignatureBouncer is Initializable, SignerRole {
     _;
   }
 
-  function initialize() public initializer {
-    SignerRole.initialize();
+  function initialize(address sender) public initializer {
+    SignerRole.initialize(sender);
   }
 
   /**

--- a/contracts/drafts/TokenVesting.sol
+++ b/contracts/drafts/TokenVesting.sol
@@ -48,12 +48,13 @@ contract TokenVesting is Initializable, Ownable {
     uint256 start,
     uint256 cliffDuration,
     uint256 duration,
-    bool revocable
+    bool revocable,
+    address sender
   )
     public
     initializer
   {
-    Ownable.initialize();
+    Ownable.initialize(sender);
 
     require(beneficiary != address(0));
     require(cliffDuration <= duration);

--- a/contracts/examples/SampleCrowdsale.sol
+++ b/contracts/examples/SampleCrowdsale.sol
@@ -18,8 +18,8 @@ contract SampleCrowdsaleToken is Initializable, ERC20Mintable {
   string public symbol;
   uint8 public decimals;
 
-  function initialize() public initializer {
-    ERC20Mintable.initialize();
+  function initialize(address sender) public initializer {
+    ERC20Mintable.initialize(sender);
 
     name = "Sample Crowdsale Token";
     symbol = "SCT";

--- a/contracts/examples/SimpleToken.sol
+++ b/contracts/examples/SimpleToken.sol
@@ -20,10 +20,10 @@ contract SimpleToken is Initializable, ERC20 {
   uint256 public constant INITIAL_SUPPLY = 10000 * (10 ** uint256(decimals));
 
   /**
-   * @dev Constructor that gives msg.sender all of existing tokens.
+   * @dev Constructor that gives sender all of existing tokens.
    */
-  function initialize() public initializer {
-    _mint(msg.sender, INITIAL_SUPPLY);
+  function initialize(address sender) public initializer {
+    _mint(sender, INITIAL_SUPPLY);
   }
 
 }

--- a/contracts/lifecycle/Pausable.sol
+++ b/contracts/lifecycle/Pausable.sol
@@ -14,8 +14,8 @@ contract Pausable is Initializable, PauserRole {
 
   bool private _paused = false;
 
-  function initialize() public initializer {
-    PauserRole.initialize();
+  function initialize(address sender) public initializer {
+    PauserRole.initialize(sender);
   }
 
   /**

--- a/contracts/mocks/BreakInvariantBountyMock.sol
+++ b/contracts/mocks/BreakInvariantBountyMock.sol
@@ -24,7 +24,7 @@ contract TargetMock is Target {
 
 contract BreakInvariantBountyMock is BreakInvariantBounty {
   constructor() public {
-    BreakInvariantBounty.initialize();
+    BreakInvariantBounty.initialize(msg.sender);
   }
 
   function _deployContract() internal returns (address) {

--- a/contracts/mocks/CapperRoleMock.sol
+++ b/contracts/mocks/CapperRoleMock.sol
@@ -5,7 +5,7 @@ import "../access/roles/CapperRole.sol";
 
 contract CapperRoleMock is CapperRole {
   constructor() public {
-    CapperRole.initialize();
+    CapperRole.initialize(msg.sender);
   }
 
   function removeCapper(address account) public {

--- a/contracts/mocks/ConditionalEscrowMock.sol
+++ b/contracts/mocks/ConditionalEscrowMock.sol
@@ -8,7 +8,7 @@ contract ConditionalEscrowMock is ConditionalEscrow {
   mapping(address => bool) private _allowed;
 
   constructor() public {
-    ConditionalEscrow.initialize();
+    ConditionalEscrow.initialize(msg.sender);
   }
 
   function setAllowed(address payee, bool allowed) public {

--- a/contracts/mocks/ERC20CappedMock.sol
+++ b/contracts/mocks/ERC20CappedMock.sol
@@ -7,7 +7,7 @@ import "./MinterRoleMock.sol";
 contract ERC20CappedMock is ERC20Capped, MinterRoleMock {
 
   constructor(uint256 cap) public {
-    ERC20Capped.initialize(cap);
+    ERC20Capped.initialize(cap, msg.sender);
   }
 
 }

--- a/contracts/mocks/ERC20MintableMock.sol
+++ b/contracts/mocks/ERC20MintableMock.sol
@@ -7,7 +7,6 @@ import "./MinterRoleMock.sol";
 contract ERC20MintableMock is ERC20Mintable, MinterRoleMock {
 
   constructor() public {
-    ERC20Mintable.initialize();
+    ERC20Mintable.initialize(msg.sender);
   }
-
 }

--- a/contracts/mocks/ERC20PausableMock.sol
+++ b/contracts/mocks/ERC20PausableMock.sol
@@ -8,7 +8,7 @@ import "./PauserRoleMock.sol";
 contract ERC20PausableMock is ERC20Pausable, PauserRoleMock {
 
   constructor(address initialAccount, uint initialBalance) public {
-    ERC20Pausable.initialize();
+    ERC20Pausable.initialize(msg.sender);
 
     _mint(initialAccount, initialBalance);
   }

--- a/contracts/mocks/ERC721FullMock.sol
+++ b/contracts/mocks/ERC721FullMock.sol
@@ -15,7 +15,8 @@ contract ERC721FullMock is ERC721Full, ERC721Mintable, ERC721MetadataMintable, E
   constructor(string name, string symbol) public
   {
     ERC721Full.initialize(name, symbol);
-    ERC721Mintable.initialize();
+    ERC721Mintable.initialize(msg.sender);
+    ERC721MetadataMintable.initialize(msg.sender);
     ERC721Burnable.initialize();
   }
 

--- a/contracts/mocks/ERC721MintableBurnableImpl.sol
+++ b/contracts/mocks/ERC721MintableBurnableImpl.sol
@@ -16,8 +16,8 @@ contract ERC721MintableBurnableImpl
     public
   {
     ERC721Full.initialize("Test", "TEST");
-    ERC721Mintable.initialize();
-    ERC721MetadataMintable.initialize();
+    ERC721Mintable.initialize(msg.sender);
+    ERC721MetadataMintable.initialize(msg.sender);
     ERC721Burnable.initialize();
   }
 }

--- a/contracts/mocks/ERC721PausableMock.sol
+++ b/contracts/mocks/ERC721PausableMock.sol
@@ -10,7 +10,7 @@ import "./PauserRoleMock.sol";
  */
 contract ERC721PausableMock is ERC721Pausable, PauserRoleMock {
   constructor() {
-    ERC721Pausable.initialize();
+    ERC721Pausable.initialize(msg.sender);
   }
 
   function mint(address to, uint256 tokenId) public {

--- a/contracts/mocks/EscrowMock.sol
+++ b/contracts/mocks/EscrowMock.sol
@@ -4,6 +4,6 @@ import "../payment/Escrow.sol";
 
 contract EscrowMock is Escrow {
   constructor() public {
-    Escrow.initialize();
+    Escrow.initialize(msg.sender);
   }
 }

--- a/contracts/mocks/IndividuallyCappedCrowdsaleImpl.sol
+++ b/contracts/mocks/IndividuallyCappedCrowdsaleImpl.sol
@@ -16,6 +16,6 @@ contract IndividuallyCappedCrowdsaleImpl
     public
   {
     Crowdsale.initialize(rate, wallet, token);
-    IndividuallyCappedCrowdsale.initialize();
+    IndividuallyCappedCrowdsale.initialize(msg.sender);
   }
 }

--- a/contracts/mocks/MinterRoleMock.sol
+++ b/contracts/mocks/MinterRoleMock.sol
@@ -5,7 +5,7 @@ import "../access/roles/MinterRole.sol";
 
 contract MinterRoleMock is MinterRole {
   constructor() public {
-    MinterRole.initialize();
+    MinterRole.initialize(msg.sender);
   }
 
   function removeMinter(address account) public {

--- a/contracts/mocks/OwnableMock.sol
+++ b/contracts/mocks/OwnableMock.sol
@@ -3,8 +3,7 @@ pragma solidity ^0.4.24;
 import { Ownable } from "../ownership/Ownable.sol";
 
 contract OwnableMock is Ownable {
-
   constructor() {
-    Ownable.initialize();
+    Ownable.initialize(msg.sender);
   }
 }

--- a/contracts/mocks/PausableMock.sol
+++ b/contracts/mocks/PausableMock.sol
@@ -10,7 +10,7 @@ contract PausableMock is Pausable, PauserRoleMock {
   uint256 public count;
 
   constructor() public {
-    Pausable.initialize();
+    Pausable.initialize(msg.sender);
 
     drasticMeasureTaken = false;
     count = 0;

--- a/contracts/mocks/PauserRoleMock.sol
+++ b/contracts/mocks/PauserRoleMock.sol
@@ -5,7 +5,7 @@ import "../access/roles/PauserRole.sol";
 
 contract PauserRoleMock is PauserRole {
   constructor() public {
-    PauserRole.initialize();
+    PauserRole.initialize(msg.sender);
   }
 
   function removePauser(address account) public {

--- a/contracts/mocks/RefundEscrowMock.sol
+++ b/contracts/mocks/RefundEscrowMock.sol
@@ -4,6 +4,6 @@ import "../payment/RefundEscrow.sol";
 
 contract RefundEscrowMock is RefundEscrow {
   constructor(address beneficiary) public {
-    RefundEscrow.initialize(beneficiary);
+    RefundEscrow.initialize(beneficiary, msg.sender);
   }
 }

--- a/contracts/mocks/SampleCrowdsaleMock.sol
+++ b/contracts/mocks/SampleCrowdsaleMock.sol
@@ -5,7 +5,7 @@ import "../examples/SampleCrowdsale.sol";
 
 contract SampleCrowdsaleTokenMock is SampleCrowdsaleToken {
   constructor() public {
-    SampleCrowdsaleToken.initialize();
+    SampleCrowdsaleToken.initialize(msg.sender);
   }
 }
 

--- a/contracts/mocks/SecondaryMock.sol
+++ b/contracts/mocks/SecondaryMock.sol
@@ -5,7 +5,7 @@ import "../ownership/Secondary.sol";
 
 contract SecondaryMock is Secondary {
   constructor() public {
-    Secondary.initialize();
+    Secondary.initialize(msg.sender);
   }
 
   function onlyPrimaryMock() public view onlyPrimary {

--- a/contracts/mocks/SignatureBouncerMock.sol
+++ b/contracts/mocks/SignatureBouncerMock.sol
@@ -6,7 +6,7 @@ import "./SignerRoleMock.sol";
 
 contract SignatureBouncerMock is SignatureBouncer, SignerRoleMock {
   constructor() public {
-    SignatureBouncer.initialize();
+    SignatureBouncer.initialize(msg.sender);
   }
 
   function checkValidSignature(address account, bytes signature)

--- a/contracts/mocks/SignerRoleMock.sol
+++ b/contracts/mocks/SignerRoleMock.sol
@@ -5,7 +5,7 @@ import "../access/roles/SignerRole.sol";
 
 contract SignerRoleMock is SignerRole {
   constructor() public {
-    SignerRole.initialize();
+    SignerRole.initialize(msg.sender);
   }
 
   function removeSigner(address account) public {

--- a/contracts/mocks/SimpleTokenMock.sol
+++ b/contracts/mocks/SimpleTokenMock.sol
@@ -4,6 +4,6 @@ import "../examples/SimpleToken.sol";
 
 contract SimpleTokenMock is SimpleToken {
   constructor() public {
-    SimpleToken.initialize();
+    SimpleToken.initialize(msg.sender);
   }
 }

--- a/contracts/mocks/TokenVestingMock.sol
+++ b/contracts/mocks/TokenVestingMock.sol
@@ -15,7 +15,8 @@ contract TokenVestingMock is TokenVesting {
       start,
       cliffDuration,
       duration,
-      revocable
+      revocable,
+      msg.sender
     );
   }
 }

--- a/contracts/ownership/Ownable.sol
+++ b/contracts/ownership/Ownable.sol
@@ -22,8 +22,8 @@ contract Ownable is Initializable {
    * @dev The Ownable constructor sets the original `owner` of the contract to the sender
    * account.
    */
-  function initialize() public initializer {
-    _owner = msg.sender;
+  function initialize(address sender) public initializer {
+    _owner = sender;
   }
 
   /**

--- a/contracts/ownership/Secondary.sol
+++ b/contracts/ownership/Secondary.sol
@@ -12,8 +12,8 @@ contract Secondary is Initializable {
   /**
    * @dev Sets the primary account to the one that is creating the Secondary contract.
    */
-  function initialize() public initializer {
-    _primary = msg.sender;
+  function initialize(address sender) public initializer {
+    _primary = sender;
   }
 
   /**

--- a/contracts/payment/ConditionalEscrow.sol
+++ b/contracts/payment/ConditionalEscrow.sol
@@ -9,8 +9,8 @@ import "./Escrow.sol";
  * @dev Base abstract escrow to only allow withdrawal if a condition is met.
  */
 contract ConditionalEscrow is Initializable, Escrow {
-  function initialize() public initializer {
-    Escrow.initialize();
+  function initialize(address sender) public initializer {
+    Escrow.initialize(sender);
   }
 
   /**

--- a/contracts/payment/Escrow.sol
+++ b/contracts/payment/Escrow.sol
@@ -20,8 +20,8 @@ contract Escrow is Initializable, Secondary {
 
   mapping(address => uint256) private _deposits;
 
-  function initialize() public initializer {
-    Secondary.initialize();
+  function initialize(address sender) public initializer {
+    Secondary.initialize(sender);
   }
 
   function depositsOf(address payee) public view returns (uint256) {

--- a/contracts/payment/PullPayment.sol
+++ b/contracts/payment/PullPayment.sol
@@ -16,7 +16,7 @@ contract PullPayment is Initializable {
     // conditional added to make initializer idempotent in case of diamond inheritance
     if (address(_escrow) == address(0)) {
       _escrow = new Escrow();
-      _escrow.initialize();
+      _escrow.initialize(address(this));
     }
   }
 

--- a/contracts/payment/RefundEscrow.sol
+++ b/contracts/payment/RefundEscrow.sol
@@ -23,9 +23,8 @@ contract RefundEscrow is Initializable, ConditionalEscrow {
    * @dev Constructor.
    * @param beneficiary The beneficiary of the deposits.
    */
-  function initialize(address beneficiary) public initializer {
-    Secondary.initialize();
-    ConditionalEscrow.initialize();
+  function initialize(address beneficiary, address sender) public initializer {
+    ConditionalEscrow.initialize(sender);
 
     require(beneficiary != address(0));
     _beneficiary = beneficiary;

--- a/contracts/token/ERC20/ERC20Capped.sol
+++ b/contracts/token/ERC20/ERC20Capped.sol
@@ -12,11 +12,11 @@ contract ERC20Capped is Initializable, ERC20Mintable {
 
   uint256 private _cap;
 
-  function initialize(uint256 cap)
+  function initialize(uint256 cap, address sender)
     public
     initializer
   {
-    ERC20Mintable.initialize();
+    ERC20Mintable.initialize(sender);
 
     require(cap > 0);
     _cap = cap;

--- a/contracts/token/ERC20/ERC20Mintable.sol
+++ b/contracts/token/ERC20/ERC20Mintable.sol
@@ -10,8 +10,8 @@ import "../../access/roles/MinterRole.sol";
  * @dev ERC20 minting logic
  */
 contract ERC20Mintable is Initializable, ERC20, MinterRole {
-  function initialize() public initializer {
-    MinterRole.initialize();
+  function initialize(address sender) public initializer {
+    MinterRole.initialize(sender);
   }
 
   /**

--- a/contracts/token/ERC20/ERC20Pausable.sol
+++ b/contracts/token/ERC20/ERC20Pausable.sol
@@ -11,8 +11,8 @@ import "../../lifecycle/Pausable.sol";
  **/
 contract ERC20Pausable is Initializable, ERC20, Pausable {
 
-  function initialize() public initializer {
-    Pausable.initialize();
+  function initialize(address sender) public initializer {
+    Pausable.initialize(sender);
   }
 
   function transfer(

--- a/contracts/token/ERC721/ERC721MetadataMintable.sol
+++ b/contracts/token/ERC721/ERC721MetadataMintable.sol
@@ -10,9 +10,9 @@ import "../../access/roles/MinterRole.sol";
  * @dev ERC721 minting logic with metadata
  */
 contract ERC721MetadataMintable is Initializable, ERC721, ERC721Metadata, MinterRole {
-  function initialize() public initializer {
+  function initialize(address sender) public initializer {
     ERC721.initialize();
-    MinterRole.initialize();
+    MinterRole.initialize(sender);
   }
 
   /**

--- a/contracts/token/ERC721/ERC721Mintable.sol
+++ b/contracts/token/ERC721/ERC721Mintable.sol
@@ -10,9 +10,9 @@ import "../../access/roles/MinterRole.sol";
  * @dev ERC721 minting logic
  */
 contract ERC721Mintable is Initializable, ERC721, MinterRole {
-  function initialize() public initializer {
+  function initialize(address sender) public initializer {
     ERC721.initialize();
-    MinterRole.initialize();
+    MinterRole.initialize(sender);
   }
 
   /**

--- a/contracts/token/ERC721/ERC721Pausable.sol
+++ b/contracts/token/ERC721/ERC721Pausable.sol
@@ -10,9 +10,9 @@ import "../../lifecycle/Pausable.sol";
  * @dev ERC721 modified with pausable transfers.
  **/
 contract ERC721Pausable is Initializable, ERC721, Pausable {
-  function initialize() public initializer {
+  function initialize(address sender) public initializer {
     ERC721.initialize();
-    Pausable.initialize();
+    Pausable.initialize(sender);
   }
 
   function approve(

--- a/test/ownership/Ownable.test.js
+++ b/test/ownership/Ownable.test.js
@@ -5,13 +5,13 @@ const { shouldBehaveLikeOwnable } = require('./Ownable.behavior');
 
 const Ownable = artifacts.require('OwnableMock');
 
-contract('Ownable', function ([_, owner, ...otherAccounts]) {
+contract('Ownable', function ([_, owner, anyone, ...otherAccounts]) {
   beforeEach(async function () {
     this.ownable = await Ownable.new({ from: owner });
   });
 
   it('cannot be reinitialized', async function () {
-    await expectThrow(this.ownable.initialize(), EVMRevert);
+    await expectThrow(this.ownable.initialize(anyone), EVMRevert);
   });
 
   shouldBehaveLikeOwnable(owner, otherAccounts);


### PR DESCRIPTION
Fixes #21.

The mocks use `msg.sender` as the `sender` value so that tests don't need to be ported (which is great, imo).