### PR TITLE
Added assertions to leaf initializers of (some) pseudo-abstract contr…

### DIFF
--- a/contracts/crowdsale/Crowdsale.sol
+++ b/contracts/crowdsale/Crowdsale.sol
@@ -141,6 +141,10 @@ contract Crowdsale is Initializable {
   // Internal interface (extensible)
   // -----------------------------------------
 
+  function _hasBeenInitialized() internal view returns (bool) {
+    return ((_rate > 0) && (_wallet != address(0)) && (_token != address(0)));
+  }
+
   /**
    * @dev Validation of an incoming purchase. Use require statements to revert state when conditions are not met. Use `super` in contracts that inherit from Crowdsale to extend their validations.
    * Example from CappedCrowdsale.sol's _preValidatePurchase method:

--- a/contracts/crowdsale/distribution/RefundableCrowdsale.sol
+++ b/contracts/crowdsale/distribution/RefundableCrowdsale.sol
@@ -26,10 +26,8 @@ contract RefundableCrowdsale is Initializable, FinalizableCrowdsale {
    * @param goal Funding goal
    */
   function initialize(uint256 goal) public initializer {
-    // Make sure TimedCrowdsale.initialize (which FinalizableCrowdsale depends on) has been
-    // called before this initializer is executed
-    require(openingTime() > 0);
-    require(closingTime() > 0);
+    // FinalizableCrowdsale depends on TimedCrowdsale
+    assert(TimedCrowdsale._hasBeenInitialized());
 
     require(goal > 0);
 

--- a/contracts/crowdsale/distribution/RefundableCrowdsale.sol
+++ b/contracts/crowdsale/distribution/RefundableCrowdsale.sol
@@ -26,6 +26,11 @@ contract RefundableCrowdsale is Initializable, FinalizableCrowdsale {
    * @param goal Funding goal
    */
   function initialize(uint256 goal) public initializer {
+    // Make sure TimedCrowdsale.initialize (which FinalizableCrowdsale depends on) has been
+    // called before this initializer is executed
+    require(openingTime() > 0);
+    require(closingTime() > 0);
+
     require(goal > 0);
 
     // conditional added to make initializer idempotent in case of diamond inheritance

--- a/contracts/crowdsale/emission/AllowanceCrowdsale.sol
+++ b/contracts/crowdsale/emission/AllowanceCrowdsale.sol
@@ -22,10 +22,7 @@ contract AllowanceCrowdsale is Initializable, Crowdsale {
    * @param tokenWallet Address holding the tokens, which has approved allowance to the crowdsale
    */
   function initialize(address tokenWallet) public initializer {
-    // Make sure Crowdsale.initialize has been called before this initializer is executed
-    assert(rate() > 0);
-    assert(wallet() != address(0));
-    assert(token() != address(0));
+    assert(Crowdsale._hasBeenInitialized());
 
     require(tokenWallet != address(0));
     _tokenWallet = tokenWallet;

--- a/contracts/crowdsale/emission/AllowanceCrowdsale.sol
+++ b/contracts/crowdsale/emission/AllowanceCrowdsale.sol
@@ -22,6 +22,11 @@ contract AllowanceCrowdsale is Initializable, Crowdsale {
    * @param tokenWallet Address holding the tokens, which has approved allowance to the crowdsale
    */
   function initialize(address tokenWallet) public initializer {
+    // Make sure Crowdsale.initialize has been called before this initializer is executed
+    assert(rate() > 0);
+    assert(wallet() != address(0));
+    assert(token() != address(0));
+
     require(tokenWallet != address(0));
     _tokenWallet = tokenWallet;
   }

--- a/contracts/crowdsale/price/IncreasingPriceCrowdsale.sol
+++ b/contracts/crowdsale/price/IncreasingPriceCrowdsale.sol
@@ -23,6 +23,10 @@ contract IncreasingPriceCrowdsale is Initializable, TimedCrowdsale {
    * @param finalRate Number of tokens a buyer gets per wei at the end of the crowdsale
    */
   function initialize(uint256 initialRate, uint256 finalRate) public initializer {
+    // Make sure TimedCrowdsale.initialize has been called before this initializer is executed
+    require(openingTime() > 0);
+    require(closingTime() > 0);
+
     require(finalRate > 0);
     require(initialRate >= finalRate);
     _initialRate = initialRate;

--- a/contracts/crowdsale/price/IncreasingPriceCrowdsale.sol
+++ b/contracts/crowdsale/price/IncreasingPriceCrowdsale.sol
@@ -23,9 +23,7 @@ contract IncreasingPriceCrowdsale is Initializable, TimedCrowdsale {
    * @param finalRate Number of tokens a buyer gets per wei at the end of the crowdsale
    */
   function initialize(uint256 initialRate, uint256 finalRate) public initializer {
-    // Make sure TimedCrowdsale.initialize has been called before this initializer is executed
-    require(openingTime() > 0);
-    require(closingTime() > 0);
+    assert(TimedCrowdsale._hasBeenInitialized());
 
     require(finalRate > 0);
     require(initialRate >= finalRate);

--- a/contracts/crowdsale/validation/CappedCrowdsale.sol
+++ b/contracts/crowdsale/validation/CappedCrowdsale.sol
@@ -19,10 +19,7 @@ contract CappedCrowdsale is Initializable, Crowdsale {
    * @param cap Max amount of wei to be contributed
    */
   function initialize(uint256 cap) public initializer {
-    // Make sure Crowdsale.initialize has been called before this initializer is executed
-    assert(rate() > 0);
-    assert(wallet() != address(0));
-    assert(token() != address(0));
+    assert(Crowdsale._hasBeenInitialized());
 
     require(cap > 0);
     _cap = cap;

--- a/contracts/crowdsale/validation/CappedCrowdsale.sol
+++ b/contracts/crowdsale/validation/CappedCrowdsale.sol
@@ -19,6 +19,11 @@ contract CappedCrowdsale is Initializable, Crowdsale {
    * @param cap Max amount of wei to be contributed
    */
   function initialize(uint256 cap) public initializer {
+    // Make sure Crowdsale.initialize has been called before this initializer is executed
+    assert(rate() > 0);
+    assert(wallet() != address(0));
+    assert(token() != address(0));
+
     require(cap > 0);
     _cap = cap;
   }

--- a/contracts/crowdsale/validation/IndividuallyCappedCrowdsale.sol
+++ b/contracts/crowdsale/validation/IndividuallyCappedCrowdsale.sol
@@ -17,10 +17,7 @@ contract IndividuallyCappedCrowdsale is Initializable, Crowdsale, CapperRole {
   mapping(address => uint256) private _caps;
 
   function initialize(address sender) public initializer {
-    // Make sure Crowdsale.initialize has been called before this initializer is executed
-    assert(rate() > 0);
-    assert(wallet() != address(0));
-    assert(token() != address(0));
+    assert(Crowdsale._hasBeenInitialized());
 
     CapperRole.initialize(sender);
   }

--- a/contracts/crowdsale/validation/IndividuallyCappedCrowdsale.sol
+++ b/contracts/crowdsale/validation/IndividuallyCappedCrowdsale.sol
@@ -17,6 +17,11 @@ contract IndividuallyCappedCrowdsale is Initializable, Crowdsale, CapperRole {
   mapping(address => uint256) private _caps;
 
   function initialize(address sender) public initializer {
+    // Make sure Crowdsale.initialize has been called before this initializer is executed
+    assert(rate() > 0);
+    assert(wallet() != address(0));
+    assert(token() != address(0));
+
     CapperRole.initialize(sender);
   }
 

--- a/contracts/crowdsale/validation/TimedCrowdsale.sol
+++ b/contracts/crowdsale/validation/TimedCrowdsale.sol
@@ -29,10 +29,7 @@ contract TimedCrowdsale is Initializable, Crowdsale {
    * @param closingTime Crowdsale closing time
    */
   function initialize(uint256 openingTime, uint256 closingTime) public initializer {
-    // Make sure Crowdsale.initialize has been called before this initializer is executed
-    assert(rate() > 0);
-    assert(wallet() != address(0));
-    assert(token() != address(0));
+    assert(Crowdsale._hasBeenInitialized());
 
     // solium-disable-next-line security/no-block-members
     require(openingTime >= block.timestamp);
@@ -71,6 +68,10 @@ contract TimedCrowdsale is Initializable, Crowdsale {
   function hasClosed() public view returns (bool) {
     // solium-disable-next-line security/no-block-members
     return block.timestamp > _closingTime;
+  }
+
+  function _hasBeenInitialized() internal view returns (bool) {
+    return ((_openingTime > 0) && (_closingTime > 0));
   }
 
   /**

--- a/contracts/crowdsale/validation/TimedCrowdsale.sol
+++ b/contracts/crowdsale/validation/TimedCrowdsale.sol
@@ -29,6 +29,11 @@ contract TimedCrowdsale is Initializable, Crowdsale {
    * @param closingTime Crowdsale closing time
    */
   function initialize(uint256 openingTime, uint256 closingTime) public initializer {
+    // Make sure Crowdsale.initialize has been called before this initializer is executed
+    assert(rate() > 0);
+    assert(wallet() != address(0));
+    assert(token() != address(0));
+
     // solium-disable-next-line security/no-block-members
     require(openingTime >= block.timestamp);
     require(closingTime >= openingTime);


### PR DESCRIPTION
Fixes https://github.com/OpenZeppelin/openzeppelin-zos/issues/22 (partially)

`MintedCrowdsale`, `FinalizableCrowdsale` and `PostDeliveryCrowdsale` are also leaf contracts, but they have no `initialize` function: I opted for not adding an empty one with these checks to them, so coverage is not complete. The situation should be better than before this PR, though.

Test coverage will decrease until https://github.com/sc-forks/solidity-coverage/issues/269 is fixed.