### PR TITLE
ERC721 contracts no longer initialize their parents.

### DIFF
--- a/contracts/introspection/ERC165.sol
+++ b/contracts/introspection/ERC165.sol
@@ -37,7 +37,7 @@ contract ERC165 is Initializable, IERC165 {
    * @dev implement supportsInterface(bytes4) using a lookup table
    */
   function supportsInterface(bytes4 interfaceId)
-    external
+    public
     view
     returns (bool)
   {

--- a/contracts/mocks/ERC721FullMock.sol
+++ b/contracts/mocks/ERC721FullMock.sol
@@ -14,10 +14,11 @@ import "../token/ERC721/ERC721Burnable.sol";
 contract ERC721FullMock is ERC721Full, ERC721Mintable, ERC721MetadataMintable, ERC721Burnable {
   constructor(string name, string symbol) public
   {
-    ERC721Full.initialize(name, symbol);
+    ERC721.initialize();
+    ERC721Metadata.initialize(name, symbol);
+    ERC721Enumerable.initialize();
     ERC721Mintable.initialize(msg.sender);
     ERC721MetadataMintable.initialize(msg.sender);
-    ERC721Burnable.initialize();
   }
 
   function exists(uint256 tokenId) public view returns (bool) {

--- a/contracts/mocks/ERC721MintableBurnableImpl.sol
+++ b/contracts/mocks/ERC721MintableBurnableImpl.sol
@@ -15,9 +15,10 @@ contract ERC721MintableBurnableImpl
   constructor()
     public
   {
-    ERC721Full.initialize("Test", "TEST");
+    ERC721.initialize();
+    ERC721Metadata.initialize("Test", "TEST");
+    ERC721Enumerable.initialize();
     ERC721Mintable.initialize(msg.sender);
     ERC721MetadataMintable.initialize(msg.sender);
-    ERC721Burnable.initialize();
   }
 }

--- a/contracts/mocks/ERC721PausableMock.sol
+++ b/contracts/mocks/ERC721PausableMock.sol
@@ -10,6 +10,7 @@ import "./PauserRoleMock.sol";
  */
 contract ERC721PausableMock is ERC721Pausable, PauserRoleMock {
   constructor() {
+    ERC721.initialize();
     ERC721Pausable.initialize(msg.sender);
   }
 

--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -57,6 +57,10 @@ contract ERC721 is Initializable, ERC165, IERC721 {
     _registerInterface(_InterfaceId_ERC721);
   }
 
+  function _hasBeenInitialized() internal view returns (bool) {
+    return supportsInterface(_InterfaceId_ERC721);
+  }
+
   /**
    * @dev Gets the balance of the specified address
    * @param owner address to query the balance of

--- a/contracts/token/ERC721/ERC721Burnable.sol
+++ b/contracts/token/ERC721/ERC721Burnable.sol
@@ -5,10 +5,6 @@ import "./ERC721.sol";
 
 
 contract ERC721Burnable is Initializable, ERC721 {
-  function initialize() public initializer {
-    ERC721.initialize();
-  }
-
   function burn(uint256 tokenId)
     public
   {

--- a/contracts/token/ERC721/ERC721Enumerable.sol
+++ b/contracts/token/ERC721/ERC721Enumerable.sol
@@ -31,11 +31,14 @@ contract ERC721Enumerable is Initializable, ERC165, ERC721, IERC721Enumerable {
    * @dev Constructor function
    */
   function initialize() public initializer {
-    ERC165.initialize();
-    ERC721.initialize();
+    require(ERC721._hasBeenInitialized());
 
     // register the supported interface to conform to ERC721 via ERC165
     _registerInterface(_InterfaceId_ERC721Enumerable);
+  }
+
+  function _hasBeenInitialized() internal view returns (bool) {
+    return supportsInterface(_InterfaceId_ERC721Enumerable);
   }
 
   /**

--- a/contracts/token/ERC721/ERC721Full.sol
+++ b/contracts/token/ERC721/ERC721Full.sol
@@ -13,14 +13,5 @@ import "./ERC721Metadata.sol";
  * @dev see https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md
  */
 contract ERC721Full is Initializable, ERC721, ERC721Enumerable, ERC721Metadata {
-  function initialize(string name, string symbol)
-    public
-    initializer
-  {
-    ERC721.initialize();
-    ERC721Enumerable.initialize();
-    ERC721Metadata.initialize(name, symbol);
-  }
-
   uint256[50] private ______gap;
 }

--- a/contracts/token/ERC721/ERC721Metadata.sol
+++ b/contracts/token/ERC721/ERC721Metadata.sol
@@ -28,14 +28,17 @@ contract ERC721Metadata is Initializable, ERC165, ERC721, IERC721Metadata {
    * @dev Constructor function
    */
   function initialize(string name, string symbol) public initializer {
-    ERC165.initialize();
-    ERC721.initialize();
+    require(ERC721._hasBeenInitialized());
 
     _name = name;
     _symbol = symbol;
 
     // register the supported interfaces to conform to ERC721 via ERC165
     _registerInterface(InterfaceId_ERC721Metadata);
+  }
+
+  function _hasBeenInitialized() internal view returns (bool) {
+    return supportsInterface(InterfaceId_ERC721Metadata);
   }
 
   /**

--- a/contracts/token/ERC721/ERC721MetadataMintable.sol
+++ b/contracts/token/ERC721/ERC721MetadataMintable.sol
@@ -11,7 +11,8 @@ import "../../access/roles/MinterRole.sol";
  */
 contract ERC721MetadataMintable is Initializable, ERC721, ERC721Metadata, MinterRole {
   function initialize(address sender) public initializer {
-    ERC721.initialize();
+    require(ERC721._hasBeenInitialized());
+    require(ERC721Metadata._hasBeenInitialized());
     MinterRole.initialize(sender);
   }
 

--- a/contracts/token/ERC721/ERC721Mintable.sol
+++ b/contracts/token/ERC721/ERC721Mintable.sol
@@ -11,7 +11,7 @@ import "../../access/roles/MinterRole.sol";
  */
 contract ERC721Mintable is Initializable, ERC721, MinterRole {
   function initialize(address sender) public initializer {
-    ERC721.initialize();
+    require(ERC721._hasBeenInitialized());
     MinterRole.initialize(sender);
   }
 

--- a/contracts/token/ERC721/ERC721Pausable.sol
+++ b/contracts/token/ERC721/ERC721Pausable.sol
@@ -11,7 +11,7 @@ import "../../lifecycle/Pausable.sol";
  **/
 contract ERC721Pausable is Initializable, ERC721, Pausable {
   function initialize(address sender) public initializer {
-    ERC721.initialize();
+    require(ERC721._hasBeenInitialized());
     Pausable.initialize(sender);
   }
 


### PR DESCRIPTION
This fixes the issue with diamonds in the ERC721 inheritance tree (namely, having to pass `name` and `symbol` multiple times to `MetadataMintable`). Initializer for all parents have to be manually called (the mocks are an example of this).

Since we'll be providing a metadata, enumerable, mintable and pausable standalone ERC721 as part of our EVM package, this shouldn't be _too_ bad, thought I'm not thrilled that initializers forced us to go this way.

I've also added some initialization safety checks in the style of #27.